### PR TITLE
Feature/find

### DIFF
--- a/packages/riot-test-utils/__tests__/find/find.spec.ts
+++ b/packages/riot-test-utils/__tests__/find/find.spec.ts
@@ -1,0 +1,49 @@
+import { find, WeakWrapper } from '../../src';
+
+describe('find', () => {
+  describe('get', () => {
+    let element: HTMLDivElement;
+    let wrapper: WeakWrapper;
+    beforeEach(() => {
+      element = document.createElement('div');
+      element.innerHTML = `
+        <form class="marked">
+          <div>
+            <input type="text" value="1">
+          </div>
+          <input type="text" value="2">
+          <div class="marked">
+            <input type="text" value="3">
+          </div>
+        </form>
+        <form>
+          <input value="4">
+        </form>
+      `;
+
+      const contextWrapper = find('.marked', element);
+      wrapper = contextWrapper.find('input');
+    });
+
+    afterEach(() => {
+      (wrapper as any) = undefined;
+      element.innerHTML = '';
+    });
+
+    it('can find selected items', () => {
+      expect(wrapper.get(0)).toBeInstanceOf(HTMLInputElement);
+      expect(wrapper.get(1)).toBeInstanceOf(HTMLInputElement);
+      expect(wrapper.get(2)).toBeInstanceOf(HTMLInputElement);
+    });
+
+    it('have unique elements', () => {
+      expect(wrapper).toHaveLength(3);
+    });
+
+    it('is sorted by appeared order in the document', () => {
+      expect(wrapper.get(0)).toHaveProperty('value', '1');
+      expect(wrapper.get(1)).toHaveProperty('value', '2');
+      expect(wrapper.get(2)).toHaveProperty('value', '3');
+    });
+  });
+});

--- a/packages/riot-test-utils/__tests__/find/get.spec.ts
+++ b/packages/riot-test-utils/__tests__/find/get.spec.ts
@@ -1,0 +1,58 @@
+import { find, WeakWrapper } from '../../src';
+
+describe('find', () => {
+  describe('get', () => {
+    let element: HTMLDivElement;
+    let wrapper: WeakWrapper;
+    beforeEach(() => {
+      element = document.createElement('div');
+      element.innerHTML = `
+        <button>found</button>
+        <form>
+          <input type="button" value="found">
+          <input type="hidden" value="not found">
+          <button disabled>not found</button>
+        </form>
+      `;
+
+      wrapper = find('button:enabled, input[type="button"]', element);
+    });
+
+    afterEach(() => {
+      (wrapper as any) = undefined;
+      element.innerHTML = '';
+    });
+
+    it('returns all the elements as array without an argument', () => {
+      const gotten = wrapper.get();
+      expect(gotten).toHaveLength(2);
+      expect(gotten).toBeInstanceOf(Array);
+      expect(gotten[0]).toBeInstanceOf(HTMLButtonElement);
+      expect(gotten[0].textContent).toBe('found');
+      expect(gotten[1]).toBeInstanceOf(HTMLInputElement);
+      expect((gotten[1] as HTMLInputElement).value).toBe('found');
+    });
+
+    it('returns same array as previous returned', () => {
+      const gotten = wrapper.get();
+      const gottenAgain = wrapper.get();
+      expect(gottenAgain).toBe(gotten);
+    });
+
+    it('returns each element with an index', () => {
+      expect(wrapper).toHaveLength(2);
+      const gotten0 = wrapper.get(0);
+      const gotten1 = wrapper.get(1);
+      expect(gotten0).toBeInstanceOf(HTMLButtonElement);
+      expect(gotten1).toBeInstanceOf(HTMLInputElement);
+    });
+
+    it('returns each element in reversed order with an negative index', () => {
+      expect(wrapper).toHaveLength(2);
+      const gottenLast0 = wrapper.get(-1);
+      const gottenLast1 = wrapper.get(-2);
+      expect(gottenLast1).toBeInstanceOf(HTMLButtonElement);
+      expect(gottenLast0).toBeInstanceOf(HTMLInputElement);
+    });
+  });
+});

--- a/packages/riot-test-utils/__tests__/find/instance.spec.ts
+++ b/packages/riot-test-utils/__tests__/find/instance.spec.ts
@@ -1,0 +1,26 @@
+import { find } from '../../src';
+
+describe('find', () => {
+  describe('instance', () => {
+    it('returns null when it has single result', () => {
+      const element = document.createElement('div');
+      element.innerHTML = '<p>Hello!</p>';
+      const wrapper = find('p', element);
+      expect(wrapper.instance).toBeNull();
+    });
+
+    it('returns null when it has multiple results', () => {
+      const element = document.createElement('div');
+      element.innerHTML = '<p></p><p></p>';
+      const wrapper = find('p', element);
+      expect(wrapper.instance).toBeNull();
+    });
+
+    it('returns null when it has no result', () => {
+      const element = document.createElement('div');
+      element.innerHTML = '';
+      const wrapper = find('p', element);
+      expect(wrapper.instance).toBeNull();
+    });
+  });
+});

--- a/packages/riot-test-utils/__tests__/find/root.spec.ts
+++ b/packages/riot-test-utils/__tests__/find/root.spec.ts
@@ -1,0 +1,28 @@
+import { find, WeakWrapper } from '../../src';
+
+describe('find', () => {
+  describe('isMounted', () => {
+    let element: HTMLDivElement;
+    let wrapper: WeakWrapper;
+
+    beforeEach(() => {
+      element = document.createElement('div');
+    });
+
+    afterEach(() => {
+      element.innerHTML = '';
+    });
+
+    it('can get root', () => {
+      element.innerHTML = '<p></p>';
+      wrapper = find('p', element);
+      expect(wrapper.root.tagName.toLowerCase()).toBe('p');
+    });
+
+    it('cannot get root when it has multiple results', () => {
+      element.innerHTML = '<p></p><div><p></p></div>';
+      wrapper = find('p', element);
+      expect(() => wrapper.root).toThrowError();
+    });
+  });
+});

--- a/packages/riot-test-utils/__tests__/find/simulate.ts
+++ b/packages/riot-test-utils/__tests__/find/simulate.ts
@@ -1,0 +1,51 @@
+import { find, WeakWrapper } from '../../src';
+
+describe('find', () => {
+  describe('simulate', () => {
+    let element: HTMLDivElement;
+    let wrapper: WeakWrapper;
+    let submitHandler: jest.MockInstance<void>;
+
+    beforeEach(() => {
+      element = document.createElement('div');
+      element.innerHTML = `
+      <form>
+        <input value="a">
+        <input value="b" checked>
+        <input value="c" disabled>
+      </form>
+      `;
+      submitHandler = jest.fn();
+      element
+        .querySelector('form')!
+        .addEventListener('submit', submitHandler as any);
+    });
+
+    afterEach(() => {
+      element
+        .querySelector('form')!
+        .removeEventListener('submit', submitHandler as any);
+      element.innerHTML = '';
+    });
+
+    it('can fire "click" event', () => {
+      wrapper = find('form', element);
+      expect(wrapper.length).toBe(1);
+
+      wrapper.simulate('submit');
+
+      expect(submitHandler).toHaveBeenCalled();
+    });
+
+    it('never cause side-effect on "click" event', () => {
+      wrapper = find('input', element);
+      expect(wrapper.length).toBe(3);
+
+      wrapper.simulate('click');
+
+      expect((wrapper.get(0) as HTMLInputElement).checked).toBe(false);
+      expect((wrapper.get(1) as HTMLInputElement).checked).toBe(true);
+      expect((wrapper.get(2) as HTMLInputElement).checked).toBe(false);
+    });
+  });
+});

--- a/packages/riot-test-utils/__tests__/mount/find.spec.ts
+++ b/packages/riot-test-utils/__tests__/mount/find.spec.ts
@@ -1,0 +1,24 @@
+import { mount, RiotWrapper } from '../../src';
+import { nestedStaticTag } from 'riot-test-renderer-shared/tags/multiTags';
+
+describe('mount', () => {
+  describe('find', () => {
+    let wrapper: RiotWrapper;
+    beforeEach(() => {
+      wrapper = mount(nestedStaticTag, 'outer');
+    });
+
+    it('finds nested tag', () => {
+      const inner = wrapper.find('inner');
+
+      expect(inner.length).toBe(1);
+      expect(inner.get(0).tagName.toLowerCase()).toBe('inner');
+    });
+
+    it('finds children of nested tag', () => {
+      const p = wrapper.find('p');
+
+      expect(p.length).toBe(1);
+    });
+  });
+});

--- a/packages/riot-test-utils/__tests__/shallow/find.spec.ts
+++ b/packages/riot-test-utils/__tests__/shallow/find.spec.ts
@@ -1,0 +1,24 @@
+import { shallow, RiotWrapper } from '../../src';
+import { nestedStaticTag } from 'riot-test-renderer-shared/tags/multiTags';
+
+describe('shallow', () => {
+  describe('find', () => {
+    let wrapper: RiotWrapper;
+    beforeEach(() => {
+      wrapper = shallow(nestedStaticTag, 'outer');
+    });
+
+    it('finds nested tag', () => {
+      const inner = wrapper.find('inner');
+
+      expect(inner.length).toBe(1);
+      expect(inner.get(0).tagName.toLowerCase()).toBe('inner');
+    });
+
+    it('never find children of nested tag', () => {
+      const p = wrapper.find('p');
+
+      expect(p.length).toBe(0);
+    });
+  });
+});

--- a/packages/riot-test-utils/rollup.config.js
+++ b/packages/riot-test-utils/rollup.config.js
@@ -11,7 +11,12 @@ export default {
   },
   external: [
     'lodash',
+    'lodash/assign',
     'lodash/each',
+    'lodash/keys',
+    'lodash/map',
+    'lodash/reduce',
+    'lodash/unionWith',
     'riot',
     'riot-shallowize',
     'simulate-event',

--- a/packages/riot-test-utils/rollup.config.umd.js
+++ b/packages/riot-test-utils/rollup.config.umd.js
@@ -6,7 +6,7 @@ export default Object.assign(
   {
     external: [
       'riot',
-      // "riot-shallowize", "simulate-event" and "lodash/each" are bundled
+      // "riot-shallowize", "simulate-event" and "lodash/*" are bundled
     ],
     output: {
       file: 'dist/index.umd.js',

--- a/packages/riot-test-utils/src/lib/utils/dom/compare.ts
+++ b/packages/riot-test-utils/src/lib/utils/dom/compare.ts
@@ -1,0 +1,5 @@
+/** compare two nodes in the appearance to sort */
+export default function compare(lhs: Node, rhs: Node) {
+  return lhs.compareDocumentPosition(rhs) <= 0;
+  // <= inclusive is required for unique
+}

--- a/packages/riot-test-utils/src/lib/utils/dom/each.ts
+++ b/packages/riot-test-utils/src/lib/utils/dom/each.ts
@@ -1,6 +1,6 @@
 export default function each<T extends Node>(
   nodes: NodeListOf<T>,
-  fn: (x: T, i: number, nodes: NodeListOf<T>) => boolean
+  fn: (x: T, i: number, nodes: NodeListOf<T>) => boolean | void
 ) {
   const n = nodes.length;
   for (let i = 0; i < n; i += 1) {

--- a/packages/riot-test-utils/src/lib/utils/dom/each.ts
+++ b/packages/riot-test-utils/src/lib/utils/dom/each.ts
@@ -1,0 +1,11 @@
+export default function each<T extends Node>(
+  nodes: NodeListOf<T>,
+  fn: (x: T, i: number, nodes: NodeListOf<T>) => boolean
+) {
+  const n = nodes.length;
+  for (let i = 0; i < n; i += 1) {
+    if (fn(nodes.item(i), i, nodes) === false) {
+      return;
+    }
+  }
+}

--- a/packages/riot-test-utils/src/lib/utils/dom/findElement.ts
+++ b/packages/riot-test-utils/src/lib/utils/dom/findElement.ts
@@ -1,0 +1,3 @@
+export default function findElement(selector: string, element: Element) {
+  return element.querySelectorAll(selector);
+}

--- a/packages/riot-test-utils/src/lib/utils/dom/findList.ts
+++ b/packages/riot-test-utils/src/lib/utils/dom/findList.ts
@@ -1,0 +1,18 @@
+import unionWith from 'lodash/unionWith';
+import reduce from 'lodash/reduce';
+import map from './map';
+import compare from './compare';
+import toNodeList from './toNodeList';
+
+export default function findList(
+  selector: string,
+  nodeList: NodeListOf<Element>
+) {
+  const arrayOfNodes = map(nodeList, x => x.querySelectorAll(selector));
+  const unitedNodes = reduce(
+    arrayOfNodes,
+    (prev, nodes) => unionWith(prev, nodes, compare),
+    [] as Array<Element>
+  );
+  return toNodeList(unitedNodes);
+}

--- a/packages/riot-test-utils/src/lib/utils/dom/map.ts
+++ b/packages/riot-test-utils/src/lib/utils/dom/map.ts
@@ -1,0 +1,11 @@
+export default function map<T extends Node, U>(
+  nodes: NodeListOf<T>,
+  fn: (x: T, i: number, nodes: NodeListOf<T>) => U
+): U[] {
+  const n = nodes.length;
+  const result = new Array<U>(n);
+  for (let i = 0; i < n; i += 1) {
+    result[i] = fn(nodes.item(i), i, nodes);
+  }
+  return result;
+}

--- a/packages/riot-test-utils/src/lib/utils/dom/toArray.ts
+++ b/packages/riot-test-utils/src/lib/utils/dom/toArray.ts
@@ -1,0 +1,8 @@
+export default function toArray<T extends Node>(nodes: NodeListOf<T>) {
+  const n = nodes.length;
+  const array = new Array<T>(n);
+  for (let i = 0; i < n; i += 1) {
+    array[i] = nodes.item(i);
+  }
+  return array;
+}

--- a/packages/riot-test-utils/src/lib/utils/dom/toNodeList.ts
+++ b/packages/riot-test-utils/src/lib/utils/dom/toNodeList.ts
@@ -1,0 +1,28 @@
+import each from 'lodash/each';
+import assign from 'lodash/assign';
+import lazy from '../misc/lazy';
+
+const empty = lazy(() => document.createDocumentFragment().childNodes);
+
+export default function toNodeList<T extends Node>(
+  array: ReadonlyArray<T>
+): NodeListOf<T> {
+  const properties: any = {};
+
+  each(array, (x, i) => {
+    properties[i] = { value: x, enumerable: true };
+  });
+
+  return Object.create(
+    empty(),
+    assign(properties, {
+      length: { value: array.length },
+      item: {
+        value: function(this: typeof properties, i: number) {
+          return this[i || 0];
+        },
+        enumerable: true,
+      },
+    })
+  );
+}

--- a/packages/riot-test-utils/src/lib/utils/misc/lazy.ts
+++ b/packages/riot-test-utils/src/lib/utils/misc/lazy.ts
@@ -1,0 +1,7 @@
+export default function lazy<T>(fn: () => T): () => T {
+  let memoized: T;
+
+  return function() {
+    return memoized === undefined ? (memoized = fn()) : memoized;
+  };
+}

--- a/packages/riot-test-utils/src/lib/wrappers/RiotWrapper.ts
+++ b/packages/riot-test-utils/src/lib/wrappers/RiotWrapper.ts
@@ -9,6 +9,8 @@ import {
 } from 'riot';
 import { toHTML, toJSON } from '../transform';
 import Simulate, { FireEvent } from '../Simulate';
+import find from './find';
+import WeakWrapper from './WeakWrapper';
 
 /**
  * Wrapper of tag instance shallow-rendered.
@@ -134,6 +136,11 @@ export default class RiotWrapper<
   toJSON(): object | null {
     const root = this.tagInstance.root;
     return toJSON(root !== undefined ? (root as any) : null);
+  }
+
+  /** Find elements by selector under this node */
+  find(selector: string): WeakWrapper {
+    return find(selector, this.root);
   }
 
   /**

--- a/packages/riot-test-utils/src/lib/wrappers/WeakWrapper.ts
+++ b/packages/riot-test-utils/src/lib/wrappers/WeakWrapper.ts
@@ -1,6 +1,10 @@
 export default class WeakWrapper {
   constructor(private nodeList: NodeListOf<Element>) {}
 
+  get instance() {
+    return null;
+  }
+
   get root() {
     return this.assertSingle();
   }

--- a/packages/riot-test-utils/src/lib/wrappers/WeakWrapper.ts
+++ b/packages/riot-test-utils/src/lib/wrappers/WeakWrapper.ts
@@ -1,5 +1,7 @@
 import toArray from '../utils/dom/toArray';
+import each from '../utils/dom/each';
 import lazy from '../utils/misc/lazy';
+import Simulate, { FireEvent } from '../Simulate';
 
 export default class WeakWrapper {
   readonly elements = lazy(() => toArray(this.nodeList));
@@ -12,6 +14,17 @@ export default class WeakWrapper {
 
   get root() {
     return this.assertSingle();
+  }
+
+  /**
+   * Simulate firing an event on all of the elements
+   *
+   * @param type event type
+   * @param options options to override event object
+   */
+  simulate<T extends {}>(type: string, options?: T) {
+    const fire = (Simulate as any)[type] as FireEvent | undefined;
+    each(this.nodeList, node => fire!(node, options));
   }
 
   get(index: number): Element;

--- a/packages/riot-test-utils/src/lib/wrappers/WeakWrapper.ts
+++ b/packages/riot-test-utils/src/lib/wrappers/WeakWrapper.ts
@@ -2,6 +2,7 @@ import toArray from '../utils/dom/toArray';
 import each from '../utils/dom/each';
 import lazy from '../utils/misc/lazy';
 import Simulate, { FireEvent } from '../Simulate';
+import findList from '../utils/dom/findList';
 
 export default class WeakWrapper {
   private readonly elements = lazy(() => toArray(this.nodeList));
@@ -45,6 +46,10 @@ export default class WeakWrapper {
 
   get length() {
     return this.nodeList.length;
+  }
+
+  find(selector: string) {
+    return new WeakWrapper(findList(selector, this.nodeList));
   }
 
   private assertSingle() {

--- a/packages/riot-test-utils/src/lib/wrappers/WeakWrapper.ts
+++ b/packages/riot-test-utils/src/lib/wrappers/WeakWrapper.ts
@@ -4,7 +4,7 @@ import lazy from '../utils/misc/lazy';
 import Simulate, { FireEvent } from '../Simulate';
 
 export default class WeakWrapper {
-  readonly elements = lazy(() => toArray(this.nodeList));
+  private readonly elements = lazy(() => toArray(this.nodeList));
 
   constructor(private nodeList: NodeListOf<Element>) {}
 

--- a/packages/riot-test-utils/src/lib/wrappers/WeakWrapper.ts
+++ b/packages/riot-test-utils/src/lib/wrappers/WeakWrapper.ts
@@ -1,4 +1,9 @@
+import toArray from '../utils/dom/toArray';
+import lazy from '../utils/misc/lazy';
+
 export default class WeakWrapper {
+  readonly elements = lazy(() => toArray(this.nodeList));
+
   constructor(private nodeList: NodeListOf<Element>) {}
 
   get instance() {
@@ -7,6 +12,26 @@ export default class WeakWrapper {
 
   get root() {
     return this.assertSingle();
+  }
+
+  get(index: number): Element;
+  get(): ReadonlyArray<Element>;
+  get(index?: number): Element | ReadonlyArray<Element> {
+    if (index === undefined) {
+      // return all the elements
+      return this.elements();
+    } else {
+      // return each element
+      if (index < 0) {
+        // ...in reversed order
+        index = this.nodeList.length + index;
+      }
+      return this.nodeList.item(index);
+    }
+  }
+
+  get length() {
+    return this.nodeList.length;
   }
 
   private assertSingle() {

--- a/packages/riot-test-utils/src/lib/wrappers/WeakWrapper.ts
+++ b/packages/riot-test-utils/src/lib/wrappers/WeakWrapper.ts
@@ -1,0 +1,14 @@
+export default class WeakWrapper {
+  constructor(private nodeList: NodeListOf<Element>) {}
+
+  get root() {
+    return this.assertSingle();
+  }
+
+  private assertSingle() {
+    if (this.nodeList.length !== 1) {
+      throw new Error('Count of nodes must be one!');
+    }
+    return this.nodeList.item(0);
+  }
+}

--- a/packages/riot-test-utils/src/lib/wrappers/WeakWrapper.ts
+++ b/packages/riot-test-utils/src/lib/wrappers/WeakWrapper.ts
@@ -8,7 +8,7 @@ export default class WeakWrapper {
 
   constructor(private nodeList: NodeListOf<Element>) {}
 
-  get instance() {
+  get instance(): null {
     return null;
   }
 

--- a/packages/riot-test-utils/src/lib/wrappers/find.ts
+++ b/packages/riot-test-utils/src/lib/wrappers/find.ts
@@ -1,7 +1,6 @@
 import WeakWrapper from './WeakWrapper';
+import findElement from '../utils/dom/findElement';
 
-function find(selector: string, element: Element) {
-  return new WeakWrapper(element.querySelectorAll(selector));
+export default function find(selector: string, element: Element) {
+  return new WeakWrapper(findElement(selector, element));
 }
-
-export default find;

--- a/packages/riot-test-utils/src/lib/wrappers/find.ts
+++ b/packages/riot-test-utils/src/lib/wrappers/find.ts
@@ -1,0 +1,7 @@
+import WeakWrapper from './WeakWrapper';
+
+function find(selector: string, element: Element) {
+  return new WeakWrapper(element.querySelectorAll(selector));
+}
+
+export default find;

--- a/packages/riot-test-utils/src/lib/wrappers/index.ts
+++ b/packages/riot-test-utils/src/lib/wrappers/index.ts
@@ -1,5 +1,7 @@
 import RiotWrapper from './RiotWrapper';
+import WeakWrapper from './WeakWrapper';
 import mount from './mount';
 import shallow from './shallow';
+import find from './find';
 
-export { RiotWrapper, mount, shallow };
+export { RiotWrapper, WeakWrapper, mount, shallow, find };


### PR DESCRIPTION
Implement find API #6 

- entry function and wrapper `WeakWrapper` as well as mount and shallow

WeakWrapper has:
- instance ... tag instance. Always null.
- root ... root DOM element. It would throw unless it is single.
- find() ... find more.
- simulate() ... event simulation.
