### PR TITLE
feat(find): implement html() on WeakWrapper as well.

### DIFF
--- a/packages/riot-test-utils/__tests__/find/html.spec.ts
+++ b/packages/riot-test-utils/__tests__/find/html.spec.ts
@@ -1,0 +1,29 @@
+import { find, WeakWrapper } from '../../src';
+
+describe('find', () => {
+  describe('html', () => {
+    let element: HTMLDivElement;
+    let wrapper: WeakWrapper;
+
+    beforeEach(() => {
+      element = document.createElement('div');
+      element.innerHTML =
+        '<div><h1>a</h1><div class="is-single"><p>b<br />c</p></div></div>';
+    });
+
+    afterEach(() => {
+      (wrapper as any) = null;
+      element.innerHTML = '';
+    });
+
+    it('get outer HTML string', () => {
+      wrapper = find('div.is-single', element);
+      expect(wrapper.html()).toBe('<div class="is-single"><p>b<br>c</p></div>');
+    });
+
+    it('throws if multiple', () => {
+      wrapper = find('div', element);
+      expect(() => wrapper.html()).toThrowError();
+    });
+  });
+});

--- a/packages/riot-test-utils/src/lib/wrappers/WeakWrapper.ts
+++ b/packages/riot-test-utils/src/lib/wrappers/WeakWrapper.ts
@@ -3,6 +3,7 @@ import each from '../utils/dom/each';
 import lazy from '../utils/misc/lazy';
 import Simulate, { FireEvent } from '../Simulate';
 import findList from '../utils/dom/findList';
+import toHTML from '../transform/toHTML';
 
 export default class WeakWrapper {
   private readonly elements = lazy(() => toArray(this.nodeList));
@@ -59,6 +60,14 @@ export default class WeakWrapper {
    */
   text() {
     return this.assertSingle().textContent;
+  }
+
+  /** Get outer-HTML string
+   *
+   * @throws {Error} unless single
+   */
+  html() {
+    return toHTML(this.assertSingle());
   }
 
   private assertSingle() {


### PR DESCRIPTION
Retrieve outer-HTML after find() #6 
